### PR TITLE
RoleServiceFactory creates Role Provider from configuration options

### DIFF
--- a/config/config.global.php
+++ b/config/config.global.php
@@ -35,19 +35,21 @@ return [
         /**
          * Configuration for role provider
          *
-         * It must be an array that contains configuration for the role provider. The provider config
-         * must follow the following format:
-         *
-         *      'LmcRbac\Role\InMemoryRoleProvider' => [
-         *          'role1' => [
-         *              'children'    => ['children1', 'children2'], // OPTIONAL
-         *              'permissions' => ['edit', 'read'] // OPTIONAL
-         *          ]
-         *      ]
+         * It must be an array that contains configuration for the role provider.
+         * The default Role Provider is 'LmcRbac\Role\InMemoryRoleProvider'
          *
          * Supported options depend of the role provider, so please refer to the official documentation
+         *
+         * The provider config for InMemoryRoleProvider must follow the following format:
+         *
+         *       'LmcRbac\Role\InMemoryRoleProvider' => [
+         *           'role1' => [
+         *               'children'    => ['children1', 'children2'], // OPTIONAL
+         *               'permissions' => ['edit', 'read'] // OPTIONAL
+         *           ]
+         *       ]
          */
-        'role_provider' => [],
+        // 'role_provider' => [],
 
         /**
          * Defining the assertion map

--- a/src/Container/RoleServiceFactory.php
+++ b/src/Container/RoleServiceFactory.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 
 namespace LmcRbac\Container;
 
+use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use LmcRbac\Options\ModuleOptions;
 use LmcRbac\Role\RoleProviderInterface;
 use LmcRbac\Service\RoleService;
@@ -38,6 +39,14 @@ final class RoleServiceFactory
     {
         $moduleOptions = $container->get(ModuleOptions::class);
 
-        return new RoleService($container->get(RoleProviderInterface::class), $moduleOptions->getGuestRole());
+        // Get the role provider from the options
+        $roleProvider = $moduleOptions->getRoleProvider();
+        if (empty($roleProvider)) {
+            throw new ServiceNotCreatedException('No role provider defined in LmcRbac configuration.');
+        }
+
+        $roleProviderName = key($roleProvider);
+
+        return new RoleService($container->get($roleProviderName), $moduleOptions->getGuestRole());
     }
 }

--- a/src/Options/ModuleOptions.php
+++ b/src/Options/ModuleOptions.php
@@ -47,10 +47,13 @@ final class ModuleOptions extends AbstractOptions
 
     /**
      * A configuration for role provider
+     * Defaults to InMemoryRoleProvider
      *
      * @var array
      */
-    protected $roleProvider = [];
+    protected $roleProvider = [
+        'LmcRbac\Role\InMemoryRoleProvider' => [],
+    ];
 
     /**
      * Constructor

--- a/test/Container/RoleServiceFactoryTest.php
+++ b/test/Container/RoleServiceFactoryTest.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 namespace LmcRbacTest\Container;
 
 use Laminas\ServiceManager\ServiceManager;
+use LmcRbac\Container\InMemoryRoleProviderFactory;
 use LmcRbac\Container\RoleServiceFactory;
 use LmcRbac\Options\ModuleOptions;
 use LmcRbac\Role\InMemoryRoleProvider;
@@ -44,9 +45,11 @@ class RoleServiceFactoryTest extends TestCase
             ],
         ]);
 
+
+
         $container = new ServiceManager(['services' => [
             ModuleOptions::class => $options,
-            RoleProviderInterface::class => new InMemoryRoleProvider([]),
+            InMemoryRoleProvider::class => new InMemoryRoleProvider([]),
         ]]);
 
         $factory = new RoleServiceFactory();
@@ -57,7 +60,7 @@ class RoleServiceFactoryTest extends TestCase
 
     public function testThrowExceptionIfNoRoleProvider(): void
     {
-        $this->expectException(\Psr\Container\NotFoundExceptionInterface::class);
+        $this->expectException(\Laminas\ServiceManager\Exception\ServiceNotCreatedException::class);
 
         $options = new ModuleOptions([
             'guest_role' => 'guest',

--- a/test/Options/ModuleOptionsTest.php
+++ b/test/Options/ModuleOptionsTest.php
@@ -31,12 +31,12 @@ class ModuleOptionsTest extends TestCase
 {
     public function testAssertModuleDefaultOptions(): void
     {
-        /** @var \LmcRbac\Options\ModuleOptions $moduleOptions */
         $moduleOptions = new \LmcRbac\Options\ModuleOptions();
 
         $this->assertEquals('guest', $moduleOptions->getGuestRole());
         $this->assertIsArray($moduleOptions->getRoleProvider());
         $this->assertIsArray($moduleOptions->getAssertionMap());
+        $this->assertEquals('LmcRbac\Role\InMemoryRoleProvider', key($moduleOptions->getRoleProvider()));
     }
 
     public function testSettersAndGetters(): void


### PR DESCRIPTION
- Fixes #45 
- Added `InMemoryRoleProvider` as default to role_provider config in `ModuleOptions`.
- RoleServiceFactory creates Role Provider from config options. Throws exception if no role_provider defined.
- Updated test cases